### PR TITLE
add homepage to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
     "audio"
   ],
   "author": "Fuchen Chen",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/fchenchen/react-native-loudness"
 }


### PR DESCRIPTION
When pod installing this library the following errors occurs:

> [!] The `react-native-loudness` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.

I guess the solutions are to either add a homepage to package.json or to remove homepage from podspec. This PR solves the problem using the former of the two methods.